### PR TITLE
Update proposal.py

### DIFF
--- a/lib/core/proposal.py
+++ b/lib/core/proposal.py
@@ -13,8 +13,8 @@ import torch.nn.functional as F
 def get_index2D(indices, shape):
     batch_size = indices.shape[0]
     num_people = indices.shape[1]
-    indices_x = torch.div(indices, shape[1], rounding_mode='trunc').reshape(batch_size, num_people, -1)
-    indices_y = (indices % shape[1]).reshape(batch_size, num_people, -1)
+    indices_x = torch.div(indices, shape[2], rounding_mode='trunc').reshape(batch_size, num_people, -1)
+    indices_y = (indices % shape[2]).reshape(batch_size, num_people, -1)
     indices = torch.cat([indices_x, indices_y], dim=2)
     return indices
 


### PR DESCRIPTION
The calculation of 2D indices was incorrect. It previously involved dividing and calculating the modulo by the number of voxels on the X axis. This only works when the voxel grid is square (equal in X and Y dimensions). The provided configuration files use square grids, so the bug wasn't apparent there. To ensure the code works for grids of any size, I've corrected the lines responsible for calculating 2D indices to use the number of voxels on the Y axis instead of X.